### PR TITLE
fix: use crane builder for pkgs-rust

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,6 +23,23 @@
         "type": "github"
       }
     },
+    "all-cabal-json": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1665552503,
+        "narHash": "sha256-r14RmRSwzv5c+bWKUDaze6pXM7nOsiz1H8nvFHJvufc=",
+        "owner": "nix-community",
+        "repo": "all-cabal-json",
+        "rev": "d7c0434eebffb305071404edcf9d5cd99703878e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "hackage",
+        "repo": "all-cabal-json",
+        "type": "github"
+      }
+    },
     "crane": {
       "flake": false,
       "locked": {
@@ -42,11 +59,11 @@
     "devshell": {
       "flake": false,
       "locked": {
-        "lastModified": 1653917170,
-        "narHash": "sha256-FyxOnEE/V4PNEcMU62ikY4FfYPo349MOhMM97HS0XEo=",
+        "lastModified": 1663445644,
+        "narHash": "sha256-+xVlcK60x7VY1vRJbNUEAHi17ZuoQxAIH4S4iUFUGBA=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "fc7a3e3adde9bbcab68af6d1e3c6eb738e296a92",
+        "rev": "e3dc3e21594fe07bdb24bdf1c8657acaa4cb8f66",
         "type": "github"
       },
       "original": {
@@ -58,9 +75,11 @@
     "dream2nix": {
       "inputs": {
         "alejandra": "alejandra",
+        "all-cabal-json": "all-cabal-json",
         "crane": "crane",
         "devshell": "devshell",
         "flake-utils-pre-commit": "flake-utils-pre-commit",
+        "ghc-utils": "ghc-utils",
         "gomod2nix": "gomod2nix",
         "mach-nix": "mach-nix",
         "nixpkgs": "nixpkgs",
@@ -68,18 +87,14 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1665161375,
-        "narHash": "sha256-7fXF1gWesgF8ScktBc/AUPr+88LekhiTN7H0gXq42Io=",
-        "owner": "nix-community",
-        "repo": "dream2nix",
-        "rev": "c926ffa5c28a1844df599dd726ea2787c4ffa18b",
-        "type": "github"
+        "lastModified": 1668243825,
+        "narHash": "sha256-CKoC77Ist6NngndNXbDwCZxSpy24owj5oZA0BBnYhzQ=",
+        "type": "git",
+        "url": "file:/home/patriot/proj/dream2nix"
       },
       "original": {
-        "owner": "nix-community",
-        "ref": "indexers",
-        "repo": "dream2nix",
-        "type": "github"
+        "type": "git",
+        "url": "file:/home/patriot/proj/dream2nix"
       }
     },
     "fenix": {
@@ -136,6 +151,22 @@
         "type": "github"
       }
     },
+    "ghc-utils": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1662774800,
+        "narHash": "sha256-1Rd2eohGUw/s1tfvkepeYpg8kCEXiIot0RijapUjAkE=",
+        "ref": "refs/heads/master",
+        "rev": "bb3a2d3dc52ff0253fb9c2812bd7aa2da03e0fea",
+        "revCount": 1072,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/bgamari/ghc-utils"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://gitlab.haskell.org/bgamari/ghc-utils"
+      }
+    },
     "gomod2nix": {
       "flake": false,
       "locked": {
@@ -169,11 +200,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657638268,
-        "narHash": "sha256-blBNtQSslAFkg0Gym9fWNJk+bPxGSZib4SOcPrmTPi4=",
+        "lastModified": 1665580254,
+        "narHash": "sha256-hO61XPkp1Hphl4HGNzj1VvDH5URt7LI6LaY/385Eul4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d80993b5f885515254746ba6d1917276ee386149",
+        "rev": "f634d427b0224a5f531ea5aa10c3960ba6ec5f0f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    dream2nix.url = "github:nix-community/dream2nix/indexers";
+    dream2nix.url = "github:nix-community/dream2nix";
   };
 
   outputs = inp:

--- a/indexes.json
+++ b/indexes.json
@@ -15,6 +15,7 @@
   {
     "name": "pkgs-rust",
     "indexer": "crates-io",
+    "builder": "crane",
     "maxPages": 5,
     "number": 500,
     "sortBy": "downloads"


### PR DESCRIPTION
This should fix the build failures, and we should use the crane builder anyways since better caching